### PR TITLE
Fix ckube watcher when labelSelector is none

### DIFF
--- a/api/proxy.go
+++ b/api/proxy.go
@@ -411,6 +411,11 @@ func isWatchRequest(r *http.Request) bool {
 func proxyPassWatch(r *ReqContext, cluster string) interface{} {
 	q := r.Request.URL.Query()
 	q.Set("timeout", "30m")
+	if v, ok := q["labelSelector"]; ok {
+		if len(v) == 1 && v[0] == "<none>" {
+			delete(q, "labelSelector")
+		}
+	}
 	r.Request.URL.RawQuery = q.Encode()
 	u := r.Request.URL.String()
 	log.Debugf("proxyPass url: %s", u)


### PR DESCRIPTION
When we try to watch a resource in ckube, if the empty `labelselector` is provided like `labelSelector: <none>`, kubeclient will throw errors like "Error creating: found '<', expected: ',' or 'end of string' seen in project events". We can just ignore the empty `labelSelector` to make watchers work properly.